### PR TITLE
Add `@exit` intrinsic

### DIFF
--- a/ex/exit.bla
+++ b/ex/exit.bla
@@ -1,0 +1,13 @@
+main() {
+    x = 0;
+    loop {
+        x = x + 12;
+        loop {
+            x = x * 10 + 3;
+            if 1 {
+                @exit(x);
+            }
+        }
+    }
+    return;
+}

--- a/src/com/Compile.hs
+++ b/src/com/Compile.hs
@@ -34,6 +34,7 @@ data Inst
   | InstSlpMs
   | InstPrCh
   | InstPrI32
+  | InstExit
   | PreInstLabelSet String
   | PreInstLabelPush String
 
@@ -148,6 +149,8 @@ compileExpr context (AstExprCall _ (AstExprVar _ "@set_heap_len") [arg]) =
   appendContextInsts (compileExpr context arg) [InstHlen]
 compileExpr context (AstExprCall _ (AstExprVar _ "@sleep_ms") [arg]) =
   appendContextInsts (compileExpr context arg) [InstSlpMs]
+compileExpr context (AstExprCall _ (AstExprVar _ "@exit") [arg]) =
+  appendContextInsts (compileExpr context arg) [InstExit]
 compileExpr
   context0
   (AstExprCall _ (AstExprVar _ "@spawn") [argFunc, argAddr]) =

--- a/src/com/Emit.hs
+++ b/src/com/Emit.hs
@@ -34,6 +34,7 @@ toInt InstSpawn = [50]
 toInt InstSlpMs = [51]
 toInt InstPrCh = [100]
 toInt InstPrI32 = [101]
+toInt InstExit = [200]
 toInt (PreInstLabelSet _) = undefined
 toInt (PreInstLabelPush _) = undefined
 

--- a/src/com/Type.hs
+++ b/src/com/Type.hs
@@ -159,7 +159,8 @@ intrinsics =
     ),
     ("@sleep_ms", Sig 0 [AstTypeI32 0] Nothing),
     ("@print_char", Sig 0 [AstTypeI32 0] Nothing),
-    ("@print_i32", Sig 0 [AstTypeI32 0] Nothing)
+    ("@print_i32", Sig 0 [AstTypeI32 0] Nothing),
+    ("@exit", Sig 0 [AstTypeI32 0] Nothing)
   ]
 
 checkFuncs :: [AstPreFunc] -> Either (String, Pos) [AstPreFunc]

--- a/src/test/main.py
+++ b/src/test/main.py
@@ -43,6 +43,9 @@ class Tests(TestCase):
     def test_empty_block(self):
         self.into_test("empty_block", 0, "1\n", "")
 
+    def test_exit(self):
+        self.into_test("exit", 123, "", "")
+
     def test_fib_lazy(self):
         self.into_test("fib_lazy", 0, "1836311903\n", "")
 

--- a/src/vm/main.cpp
+++ b/src/vm/main.cpp
@@ -47,6 +47,8 @@ enum Inst {
 
     INST_PRCH  = 100,
     INST_PRI32 = 101,
+
+    INST_EXIT = 200,
 };
 
 STATIC_ASSERT(sizeof(Inst) <= sizeof(u32));
@@ -330,6 +332,11 @@ static bool inst_pri32(Thread* thread) {
     return true;
 }
 
+[[noreturn]] static void inst_exit(Thread* thread) {
+    EXIT_IF(thread->stack.top == 0);
+    _exit(thread->stack.nodes[--thread->stack.top].as_i32);
+}
+
 static bool step(Memory* memory, Thread* thread, Time* time) {
     EXIT_IF(memory->program.insts_len <= thread->insts_index);
     switch (static_cast<Inst>(memory->program.insts[thread->insts_index++])) {
@@ -416,6 +423,9 @@ static bool step(Memory* memory, Thread* thread, Time* time) {
     }
     case INST_PRI32: {
         return inst_pri32(thread);
+    }
+    case INST_EXIT: {
+        inst_exit(thread);
     }
     default:
         EXIT();


### PR DESCRIPTION
Add support for `@exit(i32)` which allows the user to instantly halt the program and return the given error code.

Eventually, it would be nice to more fully integrate this intrinsic into the type system, such that the compiler would be smart enough to know
```
f(x i32) :: i32 {
    exit(x);
}
```
doesn't need a `return` statement, since this function will never return. That's going to involve making a few changes to type-system and `src/com/preCompile.hs`, so leaving that for another day.